### PR TITLE
Chore: Gas optimizations, unused imports, audit fixes

### DIFF
--- a/src/AlphixLVR.sol
+++ b/src/AlphixLVR.sol
@@ -50,9 +50,10 @@ contract AlphixLVR is BaseDynamicFee, AccessManaged, Pausable, IAlphixLVR {
 
     /// @inheritdoc IAlphixLVR
     function poke(PoolKey calldata key, uint24 newFee) external restricted whenNotPaused {
-        _fees[key.toId()] = newFee;
+        PoolId poolId = key.toId();
+        _fees[poolId] = newFee;
         _poke(key);
-        emit FeePoked(key.toId(), newFee);
+        emit FeePoked(poolId, newFee);
     }
 
     /// @inheritdoc IAlphixLVR

--- a/src/AlphixLVRFee.sol
+++ b/src/AlphixLVRFee.sol
@@ -76,9 +76,10 @@ contract AlphixLVRFee is BaseDynamicFee, BaseHookFee, AccessManaged, Pausable, I
 
     /// @inheritdoc IAlphixLVRFee
     function poke(PoolKey calldata key, uint24 newFee) external restricted whenNotPaused {
-        _fees[key.toId()] = newFee;
+        PoolId poolId = key.toId();
+        _fees[poolId] = newFee;
         _poke(key);
-        emit FeePoked(key.toId(), newFee);
+        emit FeePoked(poolId, newFee);
     }
 
     /// @inheritdoc IAlphixLVRFee
@@ -103,8 +104,9 @@ contract AlphixLVRFee is BaseDynamicFee, BaseHookFee, AccessManaged, Pausable, I
     /// @inheritdoc IAlphixLVRFee
     function setHookFee(PoolKey calldata key, uint24 hookFee) external restricted whenNotPaused {
         if (hookFee > MAX_HOOK_FEE) revert HookFeeTooLarge();
-        _hookFees[key.toId()] = hookFee;
-        emit HookFeeSet(key.toId(), hookFee);
+        PoolId poolId = key.toId();
+        _hookFees[poolId] = hookFee;
+        emit HookFeeSet(poolId, hookFee);
     }
 
     /// @inheritdoc IAlphixLVRFee
@@ -124,13 +126,14 @@ contract AlphixLVRFee is BaseDynamicFee, BaseHookFee, AccessManaged, Pausable, I
         if (msg.sender != address(poolManager)) revert OnlyPoolManager();
 
         Currency[] memory currencies = abi.decode(data, (Currency[]));
+        address _treasury = treasury; // cache SLOAD
         for (uint256 i = 0; i < currencies.length; i++) {
             uint256 balance = poolManager.balanceOf(address(this), currencies[i].toId());
             if (balance > 0) {
                 // Burn ERC-6909 claims (settles debt with PoolManager)
                 currencies[i].settle(poolManager, address(this), balance, true);
                 // Take actual tokens to treasury
-                currencies[i].take(poolManager, treasury, balance, false);
+                currencies[i].take(poolManager, _treasury, balance, false);
             }
         }
         return "";
@@ -141,7 +144,7 @@ contract AlphixLVRFee is BaseDynamicFee, BaseHookFee, AccessManaged, Pausable, I
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @inheritdoc IAlphixLVRFee
-    function setTreasury(address _treasury) external restricted {
+    function setTreasury(address _treasury) external restricted whenNotPaused {
         if (_treasury == address(0)) revert TreasuryNotSet();
         treasury = _treasury;
         emit TreasurySet(_treasury);

--- a/test/alphixLVRFee/BaseAlphixLVRFee.t.sol
+++ b/test/alphixLVRFee/BaseAlphixLVRFee.t.sol
@@ -10,14 +10,14 @@ import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {TickMath} from "v4-core/src/libraries/TickMath.sol";
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
 import {PoolKey} from "v4-core/src/types/PoolKey.sol";
-import {PoolId, PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
+import {PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
 import {CurrencyLibrary, Currency} from "v4-core/src/types/Currency.sol";
 import {StateLibrary} from "v4-core/src/libraries/StateLibrary.sol";
 import {LPFeeLibrary} from "v4-core/src/libraries/LPFeeLibrary.sol";
 import {IPositionManager} from "v4-periphery/src/interfaces/IPositionManager.sol";
 
 /* SOLMATE IMPORTS */
-import {MockERC20} from "solmate/src/test/utils/mocks/MockERC20.sol";
+/* solmate — used by child tests via inherited state */
 
 /* OZ IMPORTS */
 import {AccessManager} from "@openzeppelin/contracts/access/manager/AccessManager.sol";

--- a/test/alphixLVRFee/fullCycle/AlphixLVRFee_FullCycle.t.sol
+++ b/test/alphixLVRFee/fullCycle/AlphixLVRFee_FullCycle.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.26;
 import {PoolKey} from "v4-core/src/types/PoolKey.sol";
 import {PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
 import {TickMath} from "v4-core/src/libraries/TickMath.sol";
-import {LPFeeLibrary} from "v4-core/src/libraries/LPFeeLibrary.sol";
 import {StateLibrary} from "v4-core/src/libraries/StateLibrary.sol";
 import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
 import {LiquidityAmounts} from "v4-core/test/utils/LiquidityAmounts.sol";

--- a/test/alphixLVRFee/integration/concrete/AlphixLVRFee_Admin.t.sol
+++ b/test/alphixLVRFee/integration/concrete/AlphixLVRFee_Admin.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.26;
 
 import {PoolKey} from "v4-core/src/types/PoolKey.sol";
 import {PoolIdLibrary} from "v4-core/src/types/PoolId.sol";
-import {IPoolManager} from "v4-core/src/interfaces/IPoolManager.sol";
 import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {Currency} from "v4-core/src/types/Currency.sol";
 import {LPFeeLibrary} from "v4-core/src/libraries/LPFeeLibrary.sol";

--- a/test/alphixLVRFee/integration/concrete/AlphixLVRFee_Admin.t.sol
+++ b/test/alphixLVRFee/integration/concrete/AlphixLVRFee_Admin.t.sol
@@ -7,6 +7,7 @@ import {Hooks} from "v4-core/src/libraries/Hooks.sol";
 import {Currency} from "v4-core/src/types/Currency.sol";
 import {LPFeeLibrary} from "v4-core/src/libraries/LPFeeLibrary.sol";
 
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {BaseHookFee} from "@openzeppelin/uniswap-hooks/src/fee/BaseHookFee.sol";
 import {AlphixLVRFee} from "../../../../src/AlphixLVRFee.sol";
 import {IAlphixLVRFee} from "../../../../src/interfaces/IAlphixLVRFee.sol";
@@ -66,6 +67,22 @@ contract AlphixLVRFee_Admin is BaseAlphixLVRFeeTest {
         vm.prank(unauthorized);
         vm.expectRevert();
         hook.setTreasury(makeAddr("newTreasury"));
+    }
+
+    function test_setTreasury_revertsWhenPaused() public {
+        vm.prank(admin);
+        hook.pause();
+
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        hook.setTreasury(makeAddr("newTreasury"));
+
+        // Unpause and verify it works again
+        vm.prank(admin);
+        hook.unpause();
+
+        address newTreasury = makeAddr("newTreasury");
+        hook.setTreasury(newTreasury);
+        assertEq(hook.treasury(), newTreasury);
     }
 
     // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Gas:
- Cache key.toId() in poke() and setHookFee() (both LVR + LVRFee)
- Cache treasury SLOAD in unlockCallback loop

Security:
- Add whenNotPaused to setTreasury for consistency with other admin fns

Cleanup:
- Remove unused imports in test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treasury updates now revert while the contract is paused.

* **Refactor**
  * Improved gas efficiency by caching pool identifiers and frequently accessed references to avoid redundant computations.

* **Tests**
  * Removed unused imports.
  * Added a test that verifies setting the treasury reverts while paused and succeeds after unpause.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->